### PR TITLE
Add clear event emission in PackageSearch component and handle clear …

### DIFF
--- a/app/components/npm/PackageSearch.vue
+++ b/app/components/npm/PackageSearch.vue
@@ -204,6 +204,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   "update:modelValue": [value: NpmPackage | null];
   select: [pkg: NpmPackage];
+  clear: [];
 }>();
 
 const searchTerm = ref("");
@@ -318,5 +319,6 @@ const clearSelection = () => {
   selectedPackage.value = null;
   searchTerm.value = "";
   packages.value = [];
+  emit("clear");
 };
 </script>

--- a/app/pages/settings/packages/install.vue
+++ b/app/pages/settings/packages/install.vue
@@ -84,6 +84,7 @@
               <NpmPackageSearch
                 v-model="selectedNpmPackage"
                 @select="handlePackageSelect"
+                @clear="handlePackageClear"
                 :disabled="createLoading"
                 placeholder="Type to search packages (e.g., axios, lodash, express...)"
               />
@@ -97,13 +98,7 @@
             v-model="form"
             v-model:errors="errors"
             :table-name="tableName"
-            :excluded="[
-              'type',
-              'installedBy',
-              ...(packageType === 'Backend' && selectedNpmPackage
-                ? ['name']
-                : []),
-            ]"
+            :excluded="['type', 'installedBy', 'name']"
           />
         </UForm>
       </div>
@@ -181,6 +176,10 @@ function handlePackageSelect(pkg: any) {
   }
 }
 
+// Handle NPM package clear
+function handlePackageClear() {
+  initializeForm();
+}
 
 // Watch package type changes to update form
 watch(packageType, () => {


### PR DESCRIPTION
…action in install page

- Introduced a new 'clear' event in the PackageSearch component to reset the selection and search term.
- Updated the install page to handle the 'clear' event, initializing the form when the clear action is triggered.